### PR TITLE
feat: upgrade gcloud cli and AWS cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # You can find the list of the available tags here:
 # https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/GLOBAL/google-cloud-cli
 
-ARG CLOUD_SDK_VERSION=483.0.0-alpine
-ARG AWS_CLI_VERSION=2.17.7
-ARG ALPINE_VERSION=3.20
+ARG CLOUD_SDK_VERSION=492.0.0-alpine
+ARG AWS_CLI_VERSION=2.17.44
+ARG ALPINE_VERSION=3.19
 
 # To fetch the right alpine version use:
 # docker run --rm --entrypoint ash eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:${CLOUD_SDK_VERSION} -c 'cat /etc/issue'


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded Google Cloud SDK version from 483.0.0-alpine to 492.0.0-alpine
- Updated AWS CLI version from 2.17.7 to 2.17.44
- Adjusted Alpine version from 3.20 to 3.19
- These updates ensure the use of more recent and stable versions of the tools


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update CLI and Alpine versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Updated CLOUD_SDK_VERSION from 483.0.0-alpine to 492.0.0-alpine<br> <li> Updated AWS_CLI_VERSION from 2.17.7 to 2.17.44<br> <li> Changed ALPINE_VERSION from 3.20 to 3.19<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-ops-base/pull/72/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

