### PR TITLE
Update gcloud to 504.0.0 and AWS CLI v2 to 2.22.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # You can find the list of the available tags here:
 # https://console.cloud.google.com/gcr/images/google.com:cloudsdktool/GLOBAL/google-cloud-cli
 
-ARG CLOUD_SDK_VERSION=492.0.0-alpine
-ARG AWS_CLI_VERSION=2.17.44
+ARG CLOUD_SDK_VERSION=504.0.0-alpine
+ARG AWS_CLI_VERSION=2.22.18
 ARG ALPINE_VERSION=3.19
 
 # To fetch the right alpine version use:
@@ -12,7 +12,7 @@ ARG ALPINE_VERSION=3.19
 FROM ghcr.io/sparkfabrik/docker-alpine-aws-cli:${AWS_CLI_VERSION}-alpine${ALPINE_VERSION} AS awscli
 
 # Build go binaries
-FROM golang:1.22.5-alpine3.20 AS gobinaries
+FROM golang:1.23.4-alpine3.20 AS gobinaries
 
 # https://github.com/jrhouston/tfk8s
 ENV TFK8S_VERSION=0.1.10
@@ -158,7 +158,7 @@ RUN echo "Installing helm ${HELM_VERSION}..." && \
 ENV HELM_PLUGIN_MAPKUBEAPIS_VERSION=v0.5.2
 RUN echo "Installing Helm plugin Mapkubeapis ${HELM_PLUGIN_MAPKUBEAPIS_VERSION}..." && \
     helm plugin install --version ${HELM_PLUGIN_MAPKUBEAPIS_VERSION} https://github.com/helm/helm-mapkubeapis
-    
+
 # Velero.
 # https://github.com/vmware-tanzu/velero/releases
 ENV VELERO_VERSION=1.14.0


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated Google Cloud SDK to version 504.0.0 (from 492.0.0)
- Updated AWS CLI to version 2.22.18 (from 2.17.44)
- Updated Golang base image to version 1.23.4 (from 1.22.5)
- Minor whitespace fix in Helm plugins section



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Cloud SDK, AWS CLI and Golang versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Updated Google Cloud SDK version from 492.0.0 to 504.0.0<br> <li> Updated AWS CLI version from 2.17.44 to 2.22.18<br> <li> Updated Golang base image from 1.22.5 to 1.23.4<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-ops-base/pull/75/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information