### PR TITLE
fix: Renovate configuration opentofu and kubectl

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,10 +55,11 @@
         "/^Dockerfile$/"
       ],
       "matchStrings": [
-        "ENV\\s+KUBECTL_STABLE_VERSION=v?(?<currentValue>\\S+)"
+        "ENV\\s+KUBECTL_STABLE_VERSION=(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "github-releases",
-      "packageNameTemplate": "kubernetes/kubernetes"
+      "packageNameTemplate": "kubernetes/kubernetes",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "customType": "regex",
@@ -69,7 +70,7 @@
         "ENV\\s+OPENTOFU_VERSION=(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "github-releases",
-      "packageNameTemplate": "open-tofu/opentofu"
+      "packageNameTemplate": "opentofu/opentofu"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix incorrect `packageNameTemplate` for OpenTofu in Renovate config

- Correct regex for `KUBECTL_STABLE_VERSION` extraction

- Add `extractVersionTemplate` for kubectl version parsing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Fix OpenTofu and kubectl version extraction in Renovate config</code></dd></summary>
<hr>

renovate.json

<li>Corrected <code>packageNameTemplate</code> for OpenTofu from <code>open-tofu/opentofu</code> to <br><code>opentofu/opentofu</code><br> <li> Fixed regex for <code>KUBECTL_STABLE_VERSION</code> to remove optional 'v'<br> <li> Added <code>extractVersionTemplate</code> for kubectl to properly extract version <br>numbers


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-ops-base/pull/108/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>