### PR TITLE
ci: build multi-arch image on native runners instead of QEMU

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,64 +10,114 @@ env:
   RELEASE_BRANCH: master
   REGISTRY: ghcr.io
   IMAGE_NAME: ops-base
-  PLATFORMS: "linux/amd64,linux/arm64"
+
+# Least-privilege token: read the repo for checkout, push images to GHCR.
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
+  # Build every architecture on a native runner in parallel (no QEMU emulation).
+  # On master each arch is pushed by digest; the merge job assembles the final
+  # multi-arch manifest. On pull requests the build is validated only
+  # (type=cacheonly) and nothing is pushed.
+  build:
+    runs-on: ${{ matrix.platform.runner }}
+    name: build (${{ matrix.platform.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each platform is a self-contained object (name/runner/arch) so runner
+        # and arch are always defined; amd64 builds on ubuntu-latest and arm64
+        # on a native ubuntu-24.04-arm runner.
+        platform:
+          - name: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - name: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # set latest tag for main branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) }}
-            # set sha tag
-            type=sha,format=long,prefix=
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          context: .
-          platforms: ${{ env.PLATFORMS }}
-          outputs: type=cacheonly
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  deploy:
-    runs-on: ubuntu-latest
-    if: contains('["refs/heads/main", "refs/heads/master"]', github.ref)
-    steps:
-      - uses: actions/checkout@v6
-
+      # Login is only needed when we push by digest (master).
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.7.0
+        if: github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH)
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # On master: build single-arch and push by digest (no tag); the merge job
+      # assembles the final multi-arch tags from the per-arch digests.
+      # On pull requests: build for this arch and keep it in the cache only.
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform.name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform.arch }}
+          outputs: ${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) && format('type=image,name={0}/{1}/{2},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, github.repository_owner, env.IMAGE_NAME) || 'type=cacheonly' }}
+
+      - name: Export digest
+        if: github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH)
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          # The filename is the bare digest; the merge job reconstructs the ref.
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH)
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the multi-arch manifest from the per-arch digests and apply the
+  # final tags. Runs on master only.
+  merge:
+    needs: build
+    # Job-level `if` cannot read the `env` context, so the release branch is
+    # spelled out here; keep it in sync with env.RELEASE_BRANCH.
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -76,11 +126,17 @@ jobs:
             # set sha tag
             type=sha,format=long,prefix=
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: .
-          platforms: ${{ env.PLATFORMS }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create and push multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Intentional word splitting: the -t flags and the per-arch refs must
+          # each expand into separate arguments to imagetools create.
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
+            $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,11 +17,32 @@ permissions:
   packages: write
 
 jobs:
+  # Resolve "is this the release branch?" once, from env.RELEASE_BRANCH, and
+  # expose it as an output. Job-level `if` cannot read the `env` context but can
+  # read `needs`, so downstream jobs gate on this single source of truth instead
+  # of each hardcoding the branch name.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+    steps:
+      - id: check
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ "${REF}" = "refs/heads/${RELEASE_BRANCH}" ]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build every architecture on a native runner in parallel (no QEMU emulation).
-  # On master each arch is pushed by digest; the merge job assembles the final
-  # multi-arch manifest. On pull requests the build is validated only
+  # On the release branch each arch is pushed by digest; the merge job assembles
+  # the final multi-arch manifest. On pull requests the build is validated only
   # (type=cacheonly) and nothing is pushed.
   build:
+    needs: prepare
     runs-on: ${{ matrix.platform.runner }}
     name: build (${{ matrix.platform.arch }})
     strategy:
@@ -46,9 +67,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
 
-      # Login is only needed when we push by digest (master).
+      # Login is only needed when we push by digest (release branch).
       - name: Log in to the Container registry
-        if: github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH)
+        if: needs.prepare.outputs.is_release == 'true'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -58,9 +79,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # On master: build single-arch and push by digest (no tag); the merge job
-      # assembles the final multi-arch tags from the per-arch digests.
-      # On pull requests: build for this arch and keep it in the cache only.
+      # On the release branch: build single-arch and push by digest (no tag);
+      # the merge job assembles the final multi-arch tags from the per-arch
+      # digests. On pull requests: build for this arch and keep it in the cache.
       - name: Build image
         id: build
         uses: docker/build-push-action@v7
@@ -70,18 +91,23 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.platform.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform.arch }}
-          outputs: ${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) && format('type=image,name={0}/{1}/{2},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, github.repository_owner, env.IMAGE_NAME) || 'type=cacheonly' }}
+          outputs: ${{ needs.prepare.outputs.is_release == 'true' && format('type=image,name={0}/{1}/{2},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, github.repository_owner, env.IMAGE_NAME) || 'type=cacheonly' }}
 
       - name: Export digest
-        if: github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH)
+        if: needs.prepare.outputs.is_release == 'true'
         run: |
-          mkdir -p "${{ runner.temp }}/digests"
+          set -euo pipefail
           digest="${{ steps.build.outputs.digest }}"
+          if [ -z "${digest}" ]; then
+            echo "::error::build step did not produce a digest" >&2
+            exit 1
+          fi
+          mkdir -p "${{ runner.temp }}/digests"
           # The filename is the bare digest; the merge job reconstructs the ref.
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH)
+        if: needs.prepare.outputs.is_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.platform.arch }}
@@ -90,12 +116,10 @@ jobs:
           retention-days: 1
 
   # Assemble the multi-arch manifest from the per-arch digests and apply the
-  # final tags. Runs on master only.
+  # final tags. Runs on the release branch only.
   merge:
-    needs: build
-    # Job-level `if` cannot read the `env` context, so the release branch is
-    # spelled out here; keep it in sync with env.RELEASE_BRANCH.
-    if: github.ref == 'refs/heads/master'
+    needs: [prepare, build]
+    if: needs.prepare.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
@@ -121,14 +145,23 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
-            # set latest tag for main branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) }}
+            # set latest tag for the release branch
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.is_release == 'true' }}
             # set sha tag
             type=sha,format=long,prefix=
 
       - name: Create and push multi-arch manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # Fail loudly if the digests were not downloaded, instead of assembling
+          # an incomplete or empty manifest.
+          refs=( * )
+          if [ "${#refs[@]}" -eq 0 ]; then
+            echo "::error::no digest files found; expected one per architecture" >&2
+            exit 1
+          fi
           # Intentional word splitting: the -t flags and the per-arch refs must
           # each expand into separate arguments to imagetools create.
           # shellcheck disable=SC2046
@@ -138,5 +171,6 @@ jobs:
 
       - name: Inspect image
         run: |
+          set -euo pipefail
           docker buildx imagetools inspect \
             "${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

The Docker workflow built the multi-arch image by emulating `linux/arm64` with QEMU on an x86 runner, and the deploy job rebuilt every architecture from scratch. QEMU emulation is slow, and building both architectures inside a single `buildx` invocation ran them sequentially.

This reworks the workflow to build each architecture on a native runner in parallel, following the pattern used in [docker-php-drupal-nginx](https://github.com/sparkfabrik/docker-php-drupal-nginx/blob/feature/d8/.github/workflows/docker-publish.yml) and Docker's official [multi-platform on multiple runners](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners) guidance.

## What changed

- **Native runners, no QEMU.** `amd64` builds on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm`, as a parallel matrix.
- **Push by digest + merge manifest.** On `master` each architecture is pushed to GHCR by digest, then a `merge` job assembles the final multi-arch manifest and applies the tags.
- **Pull requests validate only.** Each architecture is built with `type=cacheonly`; nothing is pushed.
- **Per-arch GitHub Actions cache.** Cache warms on pull requests and is reused on merge.
- **Official Docker actions** replace the raw `buildx` shell, except the final `imagetools create` manifest step, which has no official action wrapper.
- **Action pins bumped** to their latest major versions.

## Preserved behavior

- `latest` tag on `master` and long `sha` tag, via `metadata-action`.
- Image labels, GHCR login, and least-privilege `permissions`.

## Notes

The build job composes the pushed image name from `github.repository_owner` without lowercasing, because a shell `tr` cannot run inside a workflow expression. The `sparkfabrik` owner is already lowercase, so this is fine here; a fork with an uppercase owner would need adjustment. The merge job's tags come from `metadata-action`, which lowercases automatically.


___

### **PR Type**
Enhancement


___

### **Description**
- Build multi-arch image natively per-arch instead of QEMU emulation

- Split workflow into parallel `build` matrix (amd64/arm64) and `merge` job

- Push by digest on `master`, merge manifest with final tags via `imagetools create`

- Pull requests build with `type=cacheonly` only, no push

- Add per-arch GitHub Actions build cache

- Bump Docker action pins to latest major versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["build (amd64) on ubuntu-latest"] -- "push by digest" --> C["merge job"]
  B["build (arm64) on ubuntu-24.04-arm"] -- "push by digest" --> C
  C -- "imagetools create + tag" --> D["GHCR multi-arch manifest"]
  A -- "PR: cacheonly" --> E["No push"]
  B -- "PR: cacheonly" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Rework multi-arch build to parallel native-runner matrix with merge </code><br><code>job</code></dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Replaced QEMU-based single-job multi-arch build with a parallel matrix <br>build (<code>amd64</code> on <code>ubuntu-latest</code>, <code>arm64</code> on <code>ubuntu-24.04-arm</code>), removing <br><code>setup-qemu-action</code> and the shared <code>PLATFORMS</code> env var.<br> <li> On <code>master</code>, each arch build pushes to GHCR by digest <br>(<code>push-by-digest=true</code>), uploads the digest as an artifact, and a new <br><code>merge</code> job downloads all digests to assemble the final multi-arch <br>manifest via <code>docker buildx imagetools create</code>, applying tags from <br><code>metadata-action</code>.<br> <li> On pull requests, builds run with <code>outputs: type=cacheonly</code> (validate <br>only, no push), using per-arch GitHub Actions cache <br>(<code>cache-from</code>/<code>cache-to</code> with <code>scope</code>).<br> <li> Added <code>permissions: contents: read, packages: write</code>, replaced raw <br><code>docker/build-push-action</code> deploy step with official actions, and bumped <br>pins (<code>checkout@v7</code>, <code>metadata-action@v6</code>, <code>login-action@v4</code>, <br><code>setup-buildx-action@v4</code>, <code>build-push-action@v7</code>, <code>upload-artifact@v7</code>, <br><code>download-artifact@v8</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-ops-base/pull/194/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+97/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

